### PR TITLE
AG 2025 primavara (26.04.2025) Pct 4.5: clarificare rol Adunarile Gen…

### DIFF
--- a/regulament_pregatit_feedback.txt
+++ b/regulament_pregatit_feedback.txt
@@ -201,10 +201,14 @@ Art. 28. Cele două Adunări Generale ordinare au următoarele atribuții anuale
 		c. evaluează și aprobă implementarea obiectivelor strategice pentru ultimii trei ani.
 		d. alege președintele, membrii Consiliului Director și membrii Comisiei Naționale de Cenzori.
 		e. dezbate și aprobă obiectivele strategice pentru următorii trei ani și planul trienal de acțiune al ONCR.
-	(3) A doua Adunare Generală ordinară are adițional următoarele atribuții anuale:
+	(3) Prima Adunare Generală ordinară din an (cea din primăvară) are adițional următoarele atribuții anuale:
+		a. dezbate raportul de activitate al Consiliului Director, al Echipei Executive, al Comisiei Naţionale de Cenzori;
+		b. dă descărcarea de gestiune ordonatorului principal de credite;
+		c. alege membrii Comisiei de Etică, Disciplină și Statut în funcție de expirarea mandatelor acestora
+	(4) A doua Adunare Generală ordinară din an (cea din toamnă) are adițional următoarele atribuții anuale:
 		a. Aprobă bugetul de venituri și cheltuieli al ONCR pentru anul următor, propus de Consiliul Director.
 		
-Art. 29. Raportul de activitate al structurilor naționale, precum și eventualele propuneri de modificări la Statutul și Regulamentul ONCR, vor fi comunicate, de către Echipa Executivă, Centrelor Locale, cu o lună înainte de data Adunării Generale.
+Art. 29. Propunerile de modificări la Statutul și Regulamentul ONCR vor fi comunicate, de către Echipa Executivă, Centrelor Locale, cu o lună înainte de data Adunării Generale. Raportul de activitate al structurilor naționale va fi comunicat Centrelor Locale de către Consiliul Director cu o lună înainte de prima sesiune a Adunării Generale din an (cea din primăvară).
 
 Art. 30. 
 	(1) Ordinea de zi a Adunării Generale este propusă de Consiliul Director și comunicată Centrelor Locale cu cel puțin 45 de zile înaintea datei adunării.

--- a/statut_pregatit_feedback.txt
+++ b/statut_pregatit_feedback.txt
@@ -153,27 +153,29 @@ Art. 26. Votarea
 	În cadrul Adunării Generale, deciziile vor fi luate prin majoritate simplă (50%+1 din numărul voturilor celor prezenţi). Excepţie fac cazurile expres prevăzute în Statut și Regulament.
 
 Art. 27. Atribuţii
-	(1) Cele două Adunări Generale ordinare au următoarele atribuţii anual:
-		a. dezbate raportul de activitate al Consiliului Director, al Echipei Executive, al Comisiei Naţionale de Cenzori;
-		b. dezbate prioritățile dezvoltării organizaţiei pentru anul următor şi adoptă deciziile ce se impun;
-		c. dă descărcarea de gestiune ordonatorului principal de credite;
-		d. stabileşte valoarea cotizaţiei anuale şi a cuantumului virat în contul ONCR;
-		e. decide acordarea de titluri și distincții, inclusiv a calităţii de Membru de Onoare şi Preşedinte de Onoare, la propunerea Consiliului Director;
-		f. modifică şi aprobă Statutul și Regulamentul de organizare și funcţionare al ONCR (în sesiune ordinară sau extraordinară) numai în condiţiile prevăzute de Statutul ONCR.
-		g. aprobă dizolvarea și lichidarea asociației ONCR și numește lichidatorul. 
-		h. aprobă transmiterea bunurilor rămase în urma lichidării ONCR către una sau mai multe organizații de cercetași sau organizații care au ca scop educația non-formală, potrivit propunerilor făcute de către Consiliul Director.
- 		i. hotărăște înființarea Centrelor Locale, desființarea sucursalelor și dizolvarea filialelor în condițiile prevăzute în statut;
-		j. în caz de dizolvare a unei filiale, la solicitarea organizației, ONCR nu răspunde pentru datoriile filialei, lichidatorul fiind îndreptățit să ia toate măsurile care se impun prin legislația în vigoare.
-		k. alege membrii Comisiei de Etică, Disciplină și Statut în funcție de expirarea mandatelor acestora
+	(1) Adunarea Generală ordinară are următoarele atribuţii anual:
+		a. dezbate prioritățile dezvoltării organizaţiei pentru anul următor şi adoptă deciziile ce se impun;
+		b. stabileşte valoarea cotizaţiei anuale şi a cuantumului virat în contul ONCR;
+		c. decide acordarea de titluri și distincții, inclusiv a calităţii de Membru de Onoare şi Preşedinte de Onoare, la propunerea Consiliului Director;
+		d. modifică şi aprobă Statutul și Regulamentul de organizare și funcţionare al ONCR (în sesiune ordinară sau extraordinară) numai în condiţiile prevăzute de Statutul ONCR.
+		e. aprobă dizolvarea și lichidarea asociației ONCR și numește lichidatorul.
+		f. aprobă transmiterea bunurilor rămase în urma lichidării ONCR către una sau mai multe organizații de cercetași sau organizații care au ca scop educația non-formală, potrivit propunerilor făcute de către Consiliul Director.
+		g. hotărăște înființarea Centrelor Locale, desființarea sucursalelor și dizolvarea filialelor în condițiile prevăzute în statut;
+		h. în caz de dizolvare a unei filiale, la solicitarea organizației, ONCR nu răspunde pentru datoriile filialei, lichidatorul fiind îndreptățit să ia toate măsurile care se impun prin legislația în vigoare.
 
-	(2) Adunarea Generală are următoarele atribuții trienal:
-		a. toate atribuțiile Adunării Generale anuale;
+	(2) Prima Adunare Generală din an (cea din primăvară) are următoarele atribuții trienal:
+		a. toate atribuțiile Adunării Generale anuale de la punctele (1) și (3);
 		b. evaluează separat activitatea organelor naţionale al căror mandat se încheie;
 		c. evaluează implementarea obiectivelor strategice pentru ultimii trei ani;
 		d. alege Președintele, membrii Consiliul Director şi membrii Comisiei Naţionale de Cenzori;
 		e. dezbate şi aprobă obiectivele strategice pentru următorii trei ani și planul trienal de acțiune al ONCR.
 
-	(3) A doua Adunare Generală ordinară are adițional următoarele atribuții anuale:
+	(3) Prima Adunare Generală ordinară din an (cea din primăvară) are adițional următoarele atribuții anuale:
+		a. dezbate raportul de activitate al Consiliului Director, al Echipei Executive, al Comisiei Naţionale de Cenzori;
+		b. dă descărcarea de gestiune ordonatorului principal de credite;
+		c. alege membrii Comisiei de Etică, Disciplină și Statut în funcție de expirarea mandatelor acestora
+
+	(4) A doua Adunare Generală ordinară din an (cea din toamnă) are adițional următoarele atribuții anuale:
 		a. Aprobă bugetul de venituri și cheltuieli al ONCR pentru anul următor.
 
 A 1.2 - Consiliul Director


### PR DESCRIPTION
…erale (toamna/primavara)

Se exclude raportul comprehensiv al structurilor nationale din atributiile AG de toamna; se armonizeaza Regulamentul cu Statutul privind atributiile sesiunilor AG.
- Statut Art. 27: raportul de activitate si descarcarea de gestiune se muta in atributiile primei AG din an (primavara); se restructureaza in (1) anual, (2) trienal, (3) primavara, (4) toamna.
- Regulament Art. 28: se adauga subsectiunea atributiilor AG de primavara.
- Regulament Art. 29: raportul de activitate se comunica doar inaintea AG de primavara. Voturi: 60 PENTRU / 5 / 3.
Nota: documentul-sursa (Anexa 30, 1EcQccVLl...) foloseste notatie de reliterare; textul final a fost reconstruit. Regulament Art. 28 pastreaza inconsistentele de literare preexistente in master.