### PR TITLE
AG 2025 primavara (26.04.2025) Pct 4.6: dezbaterea raportului CEDS in…

### DIFF
--- a/regulament_pregatit_feedback.txt
+++ b/regulament_pregatit_feedback.txt
@@ -202,7 +202,7 @@ Art. 28. Cele două Adunări Generale ordinare au următoarele atribuții anuale
 		d. alege președintele, membrii Consiliului Director și membrii Comisiei Naționale de Cenzori.
 		e. dezbate și aprobă obiectivele strategice pentru următorii trei ani și planul trienal de acțiune al ONCR.
 	(3) Prima Adunare Generală ordinară din an (cea din primăvară) are adițional următoarele atribuții anuale:
-		a. dezbate raportul de activitate al Consiliului Director, al Echipei Executive, al Comisiei Naţionale de Cenzori;
+		a. dezbate raportul de activitate al Consiliului Director, al Echipei Executive, al Comisiei Naţionale de Cenzori, al Comisiei de Etică, Disciplină și Statut;
 		b. dă descărcarea de gestiune ordonatorului principal de credite;
 		c. alege membrii Comisiei de Etică, Disciplină și Statut în funcție de expirarea mandatelor acestora
 	(4) A doua Adunare Generală ordinară din an (cea din toamnă) are adițional următoarele atribuții anuale:

--- a/statut_pregatit_feedback.txt
+++ b/statut_pregatit_feedback.txt
@@ -171,7 +171,7 @@ Art. 27. Atribuţii
 		e. dezbate şi aprobă obiectivele strategice pentru următorii trei ani și planul trienal de acțiune al ONCR.
 
 	(3) Prima Adunare Generală ordinară din an (cea din primăvară) are adițional următoarele atribuții anuale:
-		a. dezbate raportul de activitate al Consiliului Director, al Echipei Executive, al Comisiei Naţionale de Cenzori;
+		a. dezbate raportul de activitate al Consiliului Director, al Echipei Executive, al Comisiei Naţionale de Cenzori, al Comisiei de Etică, Disciplină și Statut;
 		b. dă descărcarea de gestiune ordonatorului principal de credite;
 		c. alege membrii Comisiei de Etică, Disciplină și Statut în funcție de expirarea mandatelor acestora
 


### PR DESCRIPTION
… Adunarea Generala

Modifica propunerea de la Pct 4.5 (Decizia 1911/25.12.2024) prin adaugarea raportului Comisiei de Etica, Disciplina si Statut la lista rapoartelor dezbatute anual de AG.
- Statut Art. 27 (3) lit. a si Regulament Art. 28 (3) lit. a: se adauga ", al Comisiei de Etica, Disciplina si Statut". Voturi: 63 PENTRU / 3 / 2.
Nota: PR stivuit peste ramura Pct 4.5 (base = ag2025p-45-rol-adunari-generale), deoarece 4.6 amendeaza decizia de la 4.5. Sursa: Anexa 32 (1QWiBEQgra...).