### PR TITLE
AG 2026 primavara (25.04.2026) Pct 11: aprobarea Statutului CL de cat…

### DIFF
--- a/regulament_pregatit_feedback.txt
+++ b/regulament_pregatit_feedback.txt
@@ -342,7 +342,7 @@ Art. 52. Consiliul Director are următoarele atribuții:
 	u. propune candidați pentru organismele OMMS sau cele europene și regionale.
 	v. stabilește componența delegațiilor Consiliului Director care reprezintă organizația în țară și străinătate, primind apoi o informare asupra problemelor discutate.
 	x. aprobă proiectele Centrelor Locale, care aduc un risc crescut organizației, conform limitelor definite în IEDLOC, oferind un răspuns solicitărilor de acest gen în cel mai scurt timp posibil.
-	y. aprobă documentele fundamentale (statut) ale tuturor Centrelor Locale pentru a-și obține personalitatea juridică și orice altă modificare a acestora, ulterior dobândirii personalității juridice, cu excepția modificărilor organelor de conducere.
+	y. aprobă documentele fundamentale (statut) ale tuturor Centrelor Locale înainte de votul Adunării Generale pentru obținerea încuviințării pentru obținerea personalității juridice, precum și orice altă modificare a acestora, ulterior dobândirii personalității juridice, cu excepția modificărilor organelor de conducere.
 	z. numește Responsabilul SfH Național și aprobă, la recomandarea Responsabilului SfH Național, componența Echipei Naționale de Safe from Harm (SfH), pentru un mandat de 3 ani.
 	aa. decide asumarea sau respingerea rapoartelor comisiilor de anchetă primite de la Echipa Națională SfH, care conțin și propuneri de sancționare a membrilor din ONCR; în cazul unei respingeri, Echipa Națională SfH trebuie să refacă ancheta cu o altă comisie.
 	bb. aprobă procedurile de lucru pentru toate structurile ONCR
@@ -631,6 +631,7 @@ Art. 97.
 		a. să cuprindă cel puțin două patrule (25 membri din care cel puțin 3 lideri)
 		b. să fi îndeplinit cel puțin criteriile minime pentru Nivelul 1 - Centre Locale în dezvoltare, în evaluarea IEDLOC.	
 		c. în cazul Grupurilor externe care cer să devină Centre Locale este necesară recomandarea din partea Centrului Local Mentor.
+		d. aprobarea Statutului Centrului Local de către Consiliul Director
 	(3) Centrele Locale astfel înființate au personalitate juridică. Filiala se constituie prin hotărârea Adunării Generale a ONCR. Personalitatea juridică se dobândește de la data înscrierii filialei în Registrul asociațiilor și fundațiilor.
 	(4) Toate Centrele Locale la înființare semnează un contract cu ONCR, prin reprezentantul legal, în numele entității, prin care primesc susținerea organizației pentru a-și desfășura activitatea și a reprezenta local ONCR, drepturi care pot fi suspendate de Consiliul Director și retrase de Adunarea Generală.
 	(5) Formatul contractului este decis de Consiliul Director și conține minimum următoarele elemente: numele și logo-ul entității, drepturile și obligațiile Centrelui Local, informații despre reprezentarea cercetășiei (misiunea, viziune, valori, reguli de brand etc.), angajamentul față de formare, angajamentul față de implicarea în comunitate, asumarea respectării Regulamentului, Statutului și a deciziilor AG și CD și condițiile de reziliere a contractului, fără a se limita la acestea.


### PR DESCRIPTION
…re CD ca pas premergator infiintarii filialelor

Propunere Biti (Andreea Farcas). Statutul unui nou Centru Local trebuie aprobat de Consiliul Director INAINTE ca propunerea de infiintare sa fie introdusa pe ordinea de zi a Adunarii Generale.
- Regulament Art. 97 (2): se adauga lit. d (aprobarea Statutului CL de catre CD).
- Regulament Art. 52 lit. y: se precizeaza "inainte de votul Adunarii Generale". Voturi: 57 PENTRU / 4 / 9. Sursa: Anexa 30 (1gxypHiZ-D...).