### PR TITLE
Fix Regulament Art. 28 (2) a: aliniere la HAG 5 — «anuale de la punct…

### DIFF
--- a/regulament_pregatit_feedback.txt
+++ b/regulament_pregatit_feedback.txt
@@ -200,7 +200,7 @@ Art. 28. Cele două Adunări Generale ordinare au următoarele atribuții anuale
 		i. alege membrii Comisiei de Etică, Disciplină și Statut, în funcție de calendarul de expirare a mandatelor acestei structuri.
 
 	(2) Trienale:
-		a. toate atribuțiile Adunării Generale anuale.
+		a. toate atribuțiile Adunării Generale anuale de la punctele (1) și (3).
 		b. evaluează și aprobă individual și colectiv activitatea organelor naționale a căror activitate se încheie.
 		c. evaluează și aprobă implementarea obiectivelor strategice pentru ultimii trei ani.
 		d. alege președintele, membrii Consiliului Director și membrii Comisiei Naționale de Cenzori.

--- a/statut_pregatit_feedback.txt
+++ b/statut_pregatit_feedback.txt
@@ -172,7 +172,7 @@ Art. 27. Atribuţii
 		e. dezbate şi aprobă obiectivele strategice pentru următorii trei ani și planul trienal de acțiune al ONCR.
 
 	(3) Prima Adunare Generală ordinară din an (cea din primăvară) are adițional următoarele atribuții anuale:
-		a. dezbate raportul de activitate al Consiliului Director, al Echipei Executive, al Comisiei Naţionale de Cenzori, al Comisiei de Etică, Disciplină și Statut;
+		a. dezbate raportul de activitate al Consiliului Director, al Echipei Executive, al Comisiei Naţionale de Cenzori;
 		b. dă descărcarea de gestiune ordonatorului principal de credite;
 		c. alege membrii Comisiei de Etică, Disciplină și Statut în funcție de expirarea mandatelor acestora
 


### PR DESCRIPTION
…ele (1) și (3)»

HAG 5 / 26.04.2025 (Pct. 4.5) a aprobat «toate atribuțiile Adunării Generale anuale de la punctele (1) și (3)». În repo, atribuțiile trienale ale Adunării Generale naționale (Art. 28 alin. (2) lit. a) conțineau doar «anuale». Se corectează doar AG națională, nu și AG a Centrului Local.